### PR TITLE
Doc/database non gitlfs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -523,6 +523,12 @@ Getting started
 
 Pull requests for feature additions and bug fixes welcome!
 
+Git LFS Files
+-------------
+
+Some database files (under [sistr/data](sistr/data)) are stored using [Git LFS](https://git-lfs.github.com/) and require you to install the Git LFS software to properly download the files (see [here](https://www.atlassian.com/git/tutorials/git-lfs#clone-respository)).
+
+If you cannot download these files using Git LFS, note that the database files are also available from PyPI in the SISTR project <https://pypi.org/project/sistr-cmd/#files>. You should be able to download the *.tar.gz* file and extract the `sistr/data` directory into the repository.
 
 Using ``sistr_cmd`` in your Python application
 ----------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -526,9 +526,9 @@ Pull requests for feature additions and bug fixes welcome!
 Git LFS Files
 -------------
 
-Some database files (under [sistr/data](sistr/data)) are stored using [Git LFS](https://git-lfs.github.com/) and require you to install the Git LFS software to properly download the files (see [here](https://www.atlassian.com/git/tutorials/git-lfs#clone-respository)).
+Some database files (under `sistr/data <https://github.com/phac-nml/sistr_cmd/tree/master/sistr/data>`_ are stored using `Git LFS <https://git-lfs.github.com/>`_ and require you to install the Git LFS software to properly download the files (see `here <https://www.atlassian.com/git/tutorials/git-lfs#clone-respository>`_).
 
-If you cannot download these files using Git LFS, note that the database files are also available from PyPI in the SISTR project <https://pypi.org/project/sistr-cmd/#files>. You should be able to download the *.tar.gz* file and extract the `sistr/data` directory into the repository.
+If you cannot download these files using Git LFS, note that the database files are also available from PyPI in the SISTR project https://pypi.org/project/sistr-cmd/#files. You should be able to download the **.tar.gz** file and extract the ``sistr/data`` directory into the repository.
 
 Using ``sistr_cmd`` in your Python application
 ----------------------------------------------


### PR DESCRIPTION
We recently got a message from GitHub about bandwidth limits for Git LFS. This adds some information in our documentation about how to use Git LFS and download database files if Git LFS is not working out properly.

This should not be as much of a concern once we make a new release, but I wanted to still have some information here in case people wished to download older database files.