### PR TITLE
Sistr/updates for release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include README.rst
 include MANIFEST.in
 include setup.py
 
-recursive-include sistr/data/ *.fasta *.txt *.csv *.msh
+include sistr/dbstatus.txt
+recursive-include sistr/data/ *

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@
 
 .. |pypi| image:: https://badge.fury.io/py/sistr-cmd.svg
     :target: https://pypi.python.org/pypi/sistr-cmd/
-.. |license| image:: https://img.shields.io/badge/License-GPL%20v3-blue.svg
-	:target: https://www.gnu.org/licenses/gpl-3.0
+.. |license| image:: https://img.shields.io/github/license/phac-nml/sistr_cmd
+	:target: https://www.apache.org/licenses/LICENSE-2.0
 .. |nbsp| unicode:: 0xA0 
    :trim:
 
@@ -552,4 +552,4 @@ License
 
 Copyright 2017 Public Health Agency of Canada
 
-Distributed under the GNU Public License version 3.0
+Distributed under the Apache 2.0 license.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from sistr.version import __version__
 classifiers = """
 Development Status :: 4 - Beta
 Environment :: Console
-License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+License :: OSI Approved :: Apache Software License
 Intended Audience :: Science/Research
 Topic :: Scientific/Engineering
 Topic :: Scientific/Engineering :: Bio-Informatics
@@ -23,7 +23,7 @@ setup(
     version=__version__,
     packages=find_packages(exclude=['tests']),
     url='https://github.com/phac-nml/sistr_cmd',
-    license='GPLv3',
+    license='Apache 2.0',
     author='Peter Kruczkiewicz',
     author_email='peter.kruczkiewicz@gmail.com',
     description=('Serovar predictions from Salmonella whole-genome sequence assemblies by determination of antigen gene'

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,9 @@
-import os
 from distutils.core import setup
 from setuptools import find_packages
-import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from sistr.version import __version__
 
 classifiers = """
-Development Status :: 3 - Alpha
+Development Status :: 4 - Beta
 Environment :: Console
 License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
 Intended Audience :: Science/Research
@@ -21,16 +18,11 @@ Programming Language :: Python :: Implementation :: CPython
 Operating System :: POSIX :: Linux
 """.strip().split('\n')
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-exec(open('sistr/version.py').read())
-
 setup(
     name='sistr_cmd',
     version=__version__,
     packages=find_packages(exclude=['tests']),
-    url='https://github.com/peterk87/sistr_cmd',
+    url='https://github.com/phac-nml/sistr_cmd',
     license='GPLv3',
     author='Peter Kruczkiewicz',
     author_email='peter.kruczkiewicz@gmail.com',
@@ -39,15 +31,7 @@ setup(
     keywords='Salmonella serotyping genotyping cgMLST BLAST Mash MinHash',
     classifiers=classifiers,
     package_dir={'sistr':'sistr'},
-    package_data={'sistr': ['data/*.msh',
-                            'data/*.csv',
-                            'data/*.txt',
-                            'data/antigens/*.fasta',
-                            'data/cgmlst/*.fasta',
-                            'data/cgmlst/*.txt',
-                            'data/cgmlst/*.csv',
-                            'data/cgmlst/*.hdf'
-                            ]},
+    include_package_data=True,
     install_requires=[
         'numpy>=1.11.1',
         'pandas>=0.18.1',


### PR DESCRIPTION
This makes a few fixes to the code before it is released in PyPI, mainly:

1. **Inclusion of database**: I set everything up so that the database files will actually be packaged up into the Python package along with the code (by changing the `MANIFEST.in` file). The total package size, including the database files, is only around 50 MB when compressed, which is small enough to be stored by PyPI. This means that when someone installs SISTR, they don't then have to wait to download the database files (and avoids issues if our irida.corefacility.ca site goes down).
2. **Consistent license**: I made the license to consistently be Apache 2.0 everywhere (it appeared as a mix of Apache and GPL before).

I've tested out this package on the test PyPI server (https://test.pypi.org/project/sistr-cmd/). If you want to install it yourself you can run:

```
python3 -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ sistr_cmd
```

Let me know what you think.