### PR TITLE
Updated location of SISTR database URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,15 @@ You can install ``sistr_cmd`` using ``pip``:
 
 **NOTE:** You will need to ensure that external dependencies are installed (i.e. ``blast+``, ``mafft``, ``mash`` [optionally])
 
+Using ``setup.py``
+------------------
+You can install ``sistr_cmd`` directly from the source code:
+
+.. code-block:: bash
+
+	python setup.py install
+
+**NOTE:** If you run into ``pycurl`` library installation issues, you can try to resolve them by installing system dependencies via a package manager such as ``apt`` (``apt install python3-pycurl libcurl4-openssl-dev libssl-dev``)
 
 Dependencies
 ============

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from setuptools import find_packages
 from setuptools.command.install import install
 from sistr.version import __version__
-from sistr.sistr_cmd import setup_sistr_dbs
+import subprocess
 
 classifiers = """
 Development Status :: 4 - Beta
@@ -20,12 +20,15 @@ Programming Language :: Python :: Implementation :: CPython
 Operating System :: POSIX :: Linux
 """.strip().split('\n')
 
-class PreInstallCommand(install):
-    """Post-installation of SISTR databases for installation mode"""
+class CustomInstallCommand(install):
+    """Pre-installation of SISTR databases for installation mode"""
     def run(self):
-        setup_sistr_dbs()
         install.run(self)
-        
+        self.do_egg_install()
+        print("SISTR DB Setup ...")
+        subprocess.run("sistr_init")
+        print("Done")
+
 
 setup(
     name='sistr_cmd',
@@ -42,7 +45,7 @@ setup(
     package_dir={'sistr':'sistr'},
     include_package_data=True,
     cmdclass={
-        'install': PreInstallCommand
+        'install': CustomInstallCommand
     },
     install_requires=[
         'numpy>=1.11.1',
@@ -57,6 +60,7 @@ setup(
     entry_points={
         'console_scripts': [
             'sistr=sistr.sistr_cmd:main',
+            'sistr_init=sistr.sistr_cmd:setup_sistr_dbs'
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from distutils.core import setup
 from setuptools import find_packages
+from setuptools.command.install import install
 from sistr.version import __version__
 from sistr.sistr_cmd import setup_sistr_dbs
-
-#download SISTR databases
-setup_sistr_dbs()
 
 classifiers = """
 Development Status :: 4 - Beta
@@ -22,6 +20,13 @@ Programming Language :: Python :: Implementation :: CPython
 Operating System :: POSIX :: Linux
 """.strip().split('\n')
 
+class PreInstallCommand(install):
+    """Post-installation of SISTR databases for installation mode"""
+    def run(self):
+        setup_sistr_dbs()
+        install.run(self)
+        
+
 setup(
     name='sistr_cmd',
     version=__version__,
@@ -36,6 +41,9 @@ setup(
     classifiers=classifiers,
     package_dir={'sistr':'sistr'},
     include_package_data=True,
+    cmdclass={
+        'install': PreInstallCommand
+    },
     install_requires=[
         'numpy>=1.11.1',
         'pandas>=0.18.1',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from distutils.core import setup
 from setuptools import find_packages
 from sistr.version import __version__
+from sistr.sistr_cmd import setup_sistr_dbs
+
+#download SISTR databases
+setup_sistr_dbs()
 
 classifiers = """
 Development Status :: 4 - Beta

--- a/sistr/src/serovar_prediction/constants.py
+++ b/sistr/src/serovar_prediction/constants.py
@@ -8,7 +8,7 @@ MASH_DISTANCE_THRESHOLD = 0.005
 CGMLST_SUBSPECIATION_DISTANCE_THRESHOLD = 0.9
 MASH_SUBSPECIATION_DISTANCE_THRESHOLD = 0.01
 
-SISTR_DB_URL = 'https://irida.corefacility.ca/downloads/sistr/database/SISTR_V_1.1_db.tar.gz'
+SISTR_DB_URL = 'https://sairidapublic.blob.core.windows.net/downloads/sistr/database/SISTR_V_1.1_db.tar.gz'
 SISTR_DATA_DIR = resource_filename('sistr','data')
 SEROVAR_TABLE_PATH = resource_filename('sistr', 'data/Salmonella-serotype_serogroup_antigen_table-WHO_2007.csv')
 WZX_FASTA_PATH = resource_filename('sistr', 'data/antigens/wzx.fasta')


### PR DESCRIPTION
The previous URL for the SISTR database (<https://irida.corefacility.ca/downloads/sistr/database/SISTR_V_1.1_db.tar.gz>) will soon no longer be available. We have moved the database to a new URL <https://sairidapublic.blob.core.windows.net/downloads/sistr/database/SISTR_V_1.1_db.tar.gz>.

This change won't need a new release of SISTR since a copy of the database files is stored in the PyPI package and installed when using `pip install sistr_cmd` (or conda install). However, this URL will need to be used for anyone who installs via the GitHub repo to do development on SISTR.